### PR TITLE
Fix error in Makefile. See http://askubuntu.com/a/194220/13756.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: $(bins)
 	@
 
 %: src/%.c
-	$(CC) -Werror -Wall -lrt $< -o $@
+	$(CC) $< -o $@ -Werror -Wall -lrt
 
 clean:
 	rm $(bins)


### PR DESCRIPTION
derek@derek-lubuntu:~/Projects/qtools$ make
cc -Werror -Wall -lrt src/qmk.c -o qmk
/tmp/ccm1fE3s.o: In function `main':
qmk.c:(.text+0x247): undefined reference to `mq_open'
collect2: error: ld returned 1 exit status
Makefile:8: recipe for target 'qmk' failed
make: *** [qmk] Error 1
